### PR TITLE
Observe `navController.previousBackStackEntry` as a state

### DIFF
--- a/app/src/main/java/com/example/cupcake/CupcakeScreen.kt
+++ b/app/src/main/java/com/example/cupcake/CupcakeScreen.kt
@@ -15,6 +15,7 @@
  */
 package com.example.cupcake
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import androidx.annotation.StringRes
@@ -40,6 +41,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavGraph
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -103,11 +105,17 @@ fun CupcakeApp(
         backStackEntry?.destination?.route ?: CupcakeScreen.Start.name
     )
 
+    @SuppressLint("RestrictedApi")
+    val backStack by navController.currentBackStack.collectAsState()
+    val previousBackStackEntry = backStack.asReversed().asSequence().drop(1).firstOrNull { entry ->
+        entry.destination !is NavGraph
+    }
+
     Scaffold(
         topBar = {
             CupcakeAppBar(
                 currentScreen = currentScreen,
-                canNavigateBack = navController.previousBackStackEntry != null,
+                canNavigateBack = previousBackStackEntry != null,
                 navigateUp = { navController.navigateUp() }
             )
         }


### PR DESCRIPTION
The direct use of `navController.previousBackStackEntry` in a composable function doesn't actually react to its changes. In the `CupcakeApp` composable function, the existing code works only because `navController.currentBackStackEntryAsState()` is observed as a state above, and when the "current entry" changes, the composable function is rerun so the "previous entry" `navController.previousBackStackEntry` is also updated. I have verified this by removing `navController.currentBackStackEntryAsState()` and then applying the fix in 2 separate commits: you can see the back navigation button doesn't show with https://github.com/huanshankeji/basic-android-kotlin-compose-training-cupcake/commit/2654076a40cf946ba125130f60fde76b748b183f, and it's back with https://github.com/huanshankeji/basic-android-kotlin-compose-training-cupcake/commit/1ebc0c632949e90a55d0b55e0c7d77d6afd6b29b.